### PR TITLE
Feat/modeling user aggregate

### DIFF
--- a/src/helpers/types/deep-partial.ts
+++ b/src/helpers/types/deep-partial.ts
@@ -1,0 +1,7 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
+    : T[P] extends object
+      ? DeepPartial<T[P]>
+      : T[P];
+};

--- a/src/modules/user/application/commands/use-cases/create-user/create-user.command.ts
+++ b/src/modules/user/application/commands/use-cases/create-user/create-user.command.ts
@@ -14,6 +14,7 @@ export interface IAddressCommand {
 }
 
 export interface IProfileCommand {
+  readonly uuid: string;
   readonly names: string[];
   readonly lastName: string;
   readonly secondLastName?: string;
@@ -23,6 +24,7 @@ export interface IProfileCommand {
 }
 
 export interface IAccountCommand {
+  readonly uuid: string;
   readonly username: string;
   readonly email: string;
   readonly password: string;

--- a/src/modules/user/application/commands/use-cases/create-user/create-user.use-case.ts
+++ b/src/modules/user/application/commands/use-cases/create-user/create-user.use-case.ts
@@ -2,9 +2,9 @@ import { Inject, Injectable } from '@nestjs/common';
 import { CommandHandler, EventPublisher, ICommandHandler } from '@nestjs/cqrs';
 
 import { CreateUserCommand } from '@user/application/commands/use-cases/create-user/create-user.command';
+import { UserAggregate } from '@user/domain/aggregates/user.aggregate';
 import { USER_REPOSITORY } from '@user/domain/constants/injection-tokens';
 import { IUserRepositoryContract } from '@user/domain/contracts/user-repository.contract';
-import { UserModel } from '@user/domain/models/user.model';
 import { CreateUserDomainService } from '@user/domain/domain-service/create-user.domain-service';
 
 @Injectable()
@@ -17,16 +17,16 @@ export class CreateUserUseCase implements ICommandHandler<CreateUserCommand> {
     private readonly repository: IUserRepositoryContract,
   ) {}
 
-  async execute(command: CreateUserCommand): Promise<UserModel> {
+  async execute(command: CreateUserCommand): Promise<UserAggregate> {
     const { account, profile } = command;
 
-    const userModel = await this.createUserDomainService.go(account, profile);
-    const user = this.publisher.mergeObjectContext(userModel);
+    const userAggregate = await this.createUserDomainService.go(account, profile);
+    const user = this.publisher.mergeObjectContext(userAggregate);
 
-    await this.repository.persist(userModel);
+    await this.repository.persist(userAggregate);
 
     user.commit();
 
-    return user;
+    return userAggregate;
   }
 }

--- a/src/modules/user/domain/contracts/user-repository.contract.ts
+++ b/src/modules/user/domain/contracts/user-repository.contract.ts
@@ -1,11 +1,10 @@
-import { ListUserModel } from '@user/domain/models/user-list.model';
-
 import { Criteria } from '@common/domain/criteria/criteria';
-import { UserModel } from '@user/domain/models/user.model';
+import { UserAggregate } from '@user/domain/aggregates/user.aggregate';
+import { ListUserModel } from '@user/domain/models/user/user-list.model';
 
 export interface IUserRepositoryContract {
-  persist(user: UserModel): Promise<UserModel>;
-  getOneBy(UUID: string): Promise<UserModel>;
+  persist(user: UserAggregate): Promise<UserAggregate>;
+  getOneBy(UUID: string): Promise<UserAggregate>;
   destroy(UUID: string): Promise<boolean>;
   archive(UUID: string): Promise<boolean>;
   matching(criteria: Criteria): Promise<ListUserModel>;

--- a/src/modules/user/domain/domain-service/create-user.domain-service.ts
+++ b/src/modules/user/domain/domain-service/create-user.domain-service.ts
@@ -1,1 +1,48 @@
-// TO DO: Build logic to create user
+import DomainException from '@common/domain/exceptions/domain.exception';
+import { UserAggregate } from '@user/domain/aggregates/user.aggregate';
+import { IUserRepositoryContract } from '@user/domain/contracts/user-repository.contract';
+import { ExceptionFactory } from '@user/domain/exceptions/exception.factory';
+import { AccountModel } from '@user/domain/models/account/account.model';
+import { ProfileModel } from '@user/domain/models/profile/profile.model';
+import { IAccountBaseSchema } from '@user/domain/schemas/account/account.schema-primitive';
+import { IProfileBaseSchema } from '@user/domain/schemas/profile/profile.schema-primitive';
+
+export class CreateUserDomainService {
+  constructor(private readonly userRepository: IUserRepositoryContract) {}
+
+  async go(account: IAccountBaseSchema, profile: IProfileBaseSchema): Promise<UserAggregate> {
+    try {
+      const accountModel = AccountModel.fromPrimitives({
+        uuid: account.uuid,
+        username: account.username,
+        password: account.password,
+        email: account.email,
+      });
+
+      const profileModel = ProfileModel.fromPrimitives({
+        uuid: profile.uuid,
+        names: profile.names,
+        lastName: profile.lastName,
+        secondLastName: profile.secondLastName,
+        phoneNumber: profile.phoneNumber,
+        gender: profile.gender,
+        address: profile.address,
+      });
+
+      const userAggregate = new UserAggregate({
+        accountModel,
+        profileModel,
+      });
+
+      await this.userRepository.persist(userAggregate);
+
+      return userAggregate;
+    } catch (error) {
+      if (error instanceof DomainException) {
+        ExceptionFactory.createException(error.name, error.message);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/user/domain/domain-service/destroy-user.domain-service.ts
+++ b/src/modules/user/domain/domain-service/destroy-user.domain-service.ts
@@ -2,7 +2,7 @@ import DomainException from '@common/domain/exceptions/domain.exception';
 import { IUserRepositoryContract } from '@user/domain/contracts/user-repository.contract';
 import { ExceptionFactory } from '@user/domain/exceptions/exception.factory';
 import { UserNotFoundException } from '@user/domain/exceptions/user-not-found.exceptions';
-import { UserModel } from '@user/domain/models/user.model';
+import { UserModel } from '@user/domain/models/user/user.model';
 
 export class DestroyUserDomainService {
   constructor(private readonly userRepository: IUserRepositoryContract) {}

--- a/src/modules/user/domain/domain-service/update-user.domain-service.ts
+++ b/src/modules/user/domain/domain-service/update-user.domain-service.ts
@@ -1,1 +1,32 @@
-// TO DO: Build logic to create user
+import DomainException from '@common/domain/exceptions/domain.exception';
+import { UserAggregate } from '@user/domain/aggregates/user.aggregate';
+import { IUserRepositoryContract } from '@user/domain/contracts/user-repository.contract';
+import { ExceptionFactory } from '@user/domain/exceptions/exception.factory';
+import { IAccountBaseSchema } from '@user/domain/schemas/account/account.schema-primitive';
+import { IProfileBaseSchema } from '@user/domain/schemas/profile/profile.schema-primitive';
+
+export class UpdateUserDomainService {
+  constructor(private readonly userRepository: IUserRepositoryContract) {}
+
+  async go(
+    uuid: string,
+    account?: Partial<IAccountBaseSchema>,
+    profile?: Partial<IProfileBaseSchema>,
+  ): Promise<UserAggregate> {
+    try {
+      const userAggregate = await this.userRepository.getOneBy(uuid);
+
+      userAggregate.update(account, profile);
+
+      await this.userRepository.persist(userAggregate);
+
+      return userAggregate;
+    } catch (error) {
+      if (error instanceof DomainException) {
+        ExceptionFactory.createException(error.name, error.message);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/user/domain/models/profile/profile.model.ts
+++ b/src/modules/user/domain/models/profile/profile.model.ts
@@ -6,9 +6,14 @@ import CreatedAt from '@common/domain/value-object/vos/created-at.vo';
 import Id from '@common/domain/value-object/vos/id.vo';
 import UpdatedAt from '@common/domain/value-object/vos/updated-at.vo';
 import UUID from '@common/domain/value-object/vos/uuid.vo';
+import { DeepPartial } from '@helpers/types/deep-partial';
 import { ProfileGenderEnum } from '@user/domain/constants/general-rules';
 import { IProfileSchema } from '@user/domain/schemas/profile/profile.schema';
-import { IProfileSchemaPrimitive } from '@user/domain/schemas/profile/profile.schema-primitive';
+import {
+  IProfileAddressSchema,
+  IProfileBaseSchema,
+  IProfileSchemaPrimitive,
+} from '@user/domain/schemas/profile/profile.schema-primitive';
 import { Gender } from '@user/domain/value-object/profile/gender.vo';
 import { LastName } from '@user/domain/value-object/profile/last-name.vo';
 import { Name } from '@user/domain/value-object/profile/name.vo';
@@ -18,9 +23,37 @@ import { SecondLastName } from '@user/domain/value-object/profile/second-last-na
 export class ProfileModel extends AggregateRoot {
   private readonly _entityRoot: IProfileSchema;
 
-  constructor(entity: IProfileSchemaPrimitive) {
+  constructor(entity: IProfileSchemaPrimitive);
+  constructor(
+    uuid: string,
+    names: string[],
+    lastName: string,
+    secondLastName: string,
+    phoneNumber: string,
+    gender: ProfileGenderEnum,
+    address: IProfileAddressSchema,
+  );
+  constructor(
+    entityOrUuid: IProfileSchemaPrimitive | string,
+    names?: string[],
+    lastName?: string,
+    secondLastName?: string,
+    phoneNumber?: string,
+    gender?: ProfileGenderEnum,
+    address?: IProfileAddressSchema,
+  ) {
     super();
-    this.hydrate(entity);
+    if (entityOrUuid instanceof Object) {
+      this.hydrate(entityOrUuid);
+    } else if (typeof entityOrUuid === 'string') {
+      this._entityRoot.uuid = new UUID(entityOrUuid);
+      this._entityRoot.names = names.map((name) => new Name(name));
+      this._entityRoot.lastName = new LastName(lastName);
+      this._entityRoot.secondLastName = new SecondLastName(secondLastName);
+      this._entityRoot.phoneNumber = new PhoneNumber(phoneNumber);
+      this._entityRoot.gender = new Gender(gender);
+      this._entityRoot.address = new Address(address);
+    }
   }
 
   get id(): number | undefined {
@@ -68,6 +101,7 @@ export class ProfileModel extends AggregateRoot {
   }
 
   public hydrate(entity: IProfileSchemaPrimitive) {
+    //TODO: Handle a domain to emit an event
     if (entity.id) this._entityRoot.id = new Id(entity.id);
     if (entity.archivedAt) this._entityRoot.archivedAt = new ArchivedAt(entity.archivedAt);
 
@@ -90,6 +124,18 @@ export class ProfileModel extends AggregateRoot {
       state: entity.address.state,
       country: entity.address.country,
     });
+  }
+
+  public static fromPrimitives(entity: IProfileBaseSchema): ProfileModel {
+    return new ProfileModel(
+      entity.uuid,
+      entity.names,
+      entity.lastName,
+      entity.secondLastName,
+      entity.phoneNumber,
+      entity.gender,
+      entity.address,
+    );
   }
 
   public toPrimitives(): IProfileSchemaPrimitive {
@@ -115,6 +161,35 @@ export class ProfileModel extends AggregateRoot {
       updatedAt: this.updatedAt,
       archivedAt: this.archivedAt,
     };
+  }
+
+  public update(entity: DeepPartial<IProfileBaseSchema>) {
+    if (entity.names && entity.names.length > 0) {
+      this._entityRoot.names = entity.names.map((name) => new Name(name));
+    }
+
+    if (entity.lastName) this._entityRoot.lastName = new LastName(entity.lastName);
+
+    if (entity.secondLastName) {
+      this._entityRoot.secondLastName = new SecondLastName(entity.secondLastName);
+    }
+
+    if (entity.phoneNumber) this._entityRoot.phoneNumber = new PhoneNumber(entity.phoneNumber);
+    if (entity.gender) this._entityRoot.gender = new Gender(entity.gender);
+
+    if (entity.address) {
+      this._entityRoot.address = new Address({
+        ...this._entityRoot.address,
+        ...(entity.address.street && { street: entity.address.street }),
+        ...(entity.address.extNumber && { extNumber: entity.address.extNumber }),
+        ...(entity.address.intNumber && { intNumber: entity.address.intNumber }),
+        ...(entity.address.neighborhood && { neighborhood: entity.address.neighborhood }),
+        ...(entity.address.zipCode && { zipCode: entity.address.zipCode }),
+        ...(entity.address.city && { city: entity.address.city }),
+        ...(entity.address.state && { state: entity.address.state }),
+        ...(entity.address.country && { country: entity.address.country }),
+      });
+    }
   }
 
   public archive() {

--- a/src/modules/user/domain/schemas/account/account.schema-primitive.ts
+++ b/src/modules/user/domain/schemas/account/account.schema-primitive.ts
@@ -1,11 +1,14 @@
 import { ISessionSchemaPrimitive } from '@user/domain/schemas/session/session.schema-primitive';
 
-export interface IAccountSchemaPrimitives {
-  id?: number;
+export interface IAccountBaseSchema {
   uuid: string;
   username: string;
   password: string;
   email: string;
+}
+
+export interface IAccountSchemaPrimitives extends IAccountBaseSchema {
+  id?: number;
   createdAt: Date;
   updatedAt: Date;
   archivedAt: Date;

--- a/src/modules/user/domain/schemas/profile/profile.schema-primitive.ts
+++ b/src/modules/user/domain/schemas/profile/profile.schema-primitive.ts
@@ -1,26 +1,31 @@
 import { ProfileGenderEnum } from '@user/domain/constants/general-rules';
 
-export interface IProfileSchemaPrimitive {
-  id?: number;
+export interface IProfileAddressSchema {
+  street: string;
+  extNumber: string;
+  intNumber: string | null;
+  neighborhood: string;
+  zipCode: string;
+  city: string;
+  state: string;
+  country: string;
+}
+
+export interface IProfileBaseSchema {
   uuid: string;
   names: string[];
   lastName: string;
-  secondLastName: string;
+  secondLastName?: string;
   phoneNumber: string;
   gender: ProfileGenderEnum;
-  address: {
-    street: string;
-    extNumber: string;
-    intNumber: string | null;
-    neighborhood: string;
-    zipCode: string;
-    city: string;
-    state: string;
-    country: string;
-  };
+  address: IProfileAddressSchema;
+}
+
+export interface IProfileSchemaPrimitive extends IProfileBaseSchema {
+  id?: number;
   createdAt: Date;
   updatedAt: Date;
-  archivedAt?: Date;
+  archivedAt: Date;
 }
 
 export interface IListProfileSchemaPrimitive {

--- a/src/modules/user/infrastructure/persistence/typeorm/repositories/user-typeorm.repository.ts
+++ b/src/modules/user/infrastructure/persistence/typeorm/repositories/user-typeorm.repository.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ListUserModel } from '@user/domain/models/list-user.model';
 import { Repository } from 'typeorm';
 
 import { Criteria } from '@common/domain/criteria/criteria';
 import { TypeormRepository } from '@common/infrastructure/persistence/typeorm/typeorm-repository';
 import { IUserRepositoryContract } from '@user/domain/contracts/user-repository.contract';
-import { UserModel } from '@user/domain/models/user.model';
+import { ListUserModel } from '@user/domain/models/user/user-list.model';
+import { UserModel } from '@user/domain/models/user/user.model';
 import { UserEntity } from '@user/infrastructure/persistence/typeorm/entities/user.entity';
 
 @Injectable()


### PR DESCRIPTION
This pull request includes significant changes to the user domain, focusing on the transition from `UserModel` to `UserAggregate`, and the introduction of partial update capabilities for user profiles and accounts. The most important changes are grouped into schema updates, model updates, and service updates.

### Schema Updates:
* Introduced `IUserSchemaAggregate` to encapsulate user, account, and profile models within a single aggregate.
* Split `IAccountSchemaPrimitives` into `IAccountBaseSchema` and `IAccountSchemaPrimitives` to better distinguish between base attributes and full schema.
* Defined `IProfileAddressSchema` separately to better manage profile address attributes.

### Model Updates:
* Updated `UserAggregate` to use the new `IUserSchemaAggregate` and added methods for partial updates and archiving.
* Added static `fromPrimitives` and `update` methods to `AccountModel` and `ProfileModel` for easier instantiation and modification. [[1]](diffhunk://#diff-78a15710911abbe0e309ae60149236e1c4264c4bc9c91aeac9378c1dcd2ab2daR95-R98) [[2]](diffhunk://#diff-aa23f0f943d4ff0d69104272dcb3a882a28c5106029076ed641e2d771e666c67R129-R140)
* Refactored `ProfileModel` to handle partial updates using the new `DeepPartial` type.

### Service Updates:
* Modified `CreateUserUseCase` to return `UserAggregate` instead of `UserModel` and updated repository interactions accordingly.
* Implemented `CreateUserDomainService` and `UpdateUserDomainService` to handle user creation and updates using the new aggregate structure. [[1]](diffhunk://#diff-c089b639c203773d98507a5769069468fa2341e1053b404c1cc696308cc86c58L1-R48) [[2]](diffhunk://#diff-85c7ae2e7683c94835ebf37acf4568047b6872787fc4e5d0ff9a78b176617b67L1-R32)

These changes collectively improve the flexibility and maintainability of the user domain by leveraging aggregates and partial updates.