### PR TITLE
Feat/udate session failed

### DIFF
--- a/src/modules/role/infrastructure/controllers/queries/get-role/get-role.controller.ts
+++ b/src/modules/role/infrastructure/controllers/queries/get-role/get-role.controller.ts
@@ -4,9 +4,9 @@ import { MessagePattern, Payload, RpcException } from '@nestjs/microservices';
 
 import { CMDS_HADES } from '@common/infrastructure/controllers/constants';
 import { GetRoleQuery } from '@role/application/queries/get-role/get-role.query';
+import { RoleModel } from '@role/domain/models/role.model';
 import { GetRoleInputDto } from '@role/infrastructure/controllers/queries/get-role/get-role-input.dto';
 import { GetRoleOutputDto } from '@role/infrastructure/controllers/queries/get-role/get-role-output.dto';
-import { RoleModel } from '@role/domain/models/role.model';
 
 @Controller()
 export class GetRoleController {

--- a/src/modules/session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.command.ts
+++ b/src/modules/session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.command.ts
@@ -1,17 +1,19 @@
 import { ICommand } from '@nestjs/cqrs';
 
-export class ActivateInactiveSessionCommand implements ICommand {
+export class ActivateInvalidSessionCommand implements ICommand {
   public readonly uuid: string;
-  public readonly sessionClosedType: string;
-  public readonly loggedOutAt: Date;
+  public readonly sessionDuration: number;
+  public readonly token: string;
+  public readonly expiresInAt: Date;
+  public readonly loggedInAt: Date;
   public readonly refreshToken: string;
-  public readonly failedAttempts: number;
 
-  constructor(root: ActivateInactiveSessionCommand) {
+  constructor(root: ActivateInvalidSessionCommand) {
     this.uuid = root.uuid;
-    this.sessionClosedType = root.sessionClosedType;
-    this.loggedOutAt = root.loggedOutAt;
+    this.sessionDuration = root.sessionDuration;
+    this.token = root.token;
+    this.expiresInAt = root.expiresInAt;
+    this.loggedInAt = root.loggedInAt;
     this.refreshToken = root.refreshToken;
-    this.failedAttempts = root.failedAttempts;
   }
 }

--- a/src/modules/session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.use-case.ts
+++ b/src/modules/session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.use-case.ts
@@ -1,0 +1,31 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CommandHandler, EventPublisher, ICommandHandler } from '@nestjs/cqrs';
+
+import { ActivateInvalidSessionCommand } from '@session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.command';
+import { SESSION_REPOSITORY } from '@session/domain/constants/injection-tokens';
+import { ISessionRepositoryContract } from '@session/domain/contracts/session-repository.contract';
+import { ActivateInvalidSessionDomainService } from '@session/domain/domain-services/activate-invalid-session.domain-service';
+import { SessionModel } from '@session/domain/models/session.model';
+
+@Injectable()
+@CommandHandler(ActivateInvalidSessionCommand)
+export class ActiveInvalidSessionUseCase implements ICommandHandler<ActivateInvalidSessionCommand> {
+  constructor(
+    @Inject(SESSION_REPOSITORY)
+    private readonly repository: ISessionRepositoryContract,
+    private readonly publisher: EventPublisher,
+    private readonly activateInvalidSessionDomainService: ActivateInvalidSessionDomainService,
+  ) {}
+
+  async execute(command: ActivateInvalidSessionCommand): Promise<SessionModel> {
+    const sessionModel = await this.activateInvalidSessionDomainService.go(command);
+
+    const sessionContext = this.publisher.mergeObjectContext(sessionModel);
+
+    await this.repository.persist(sessionModel);
+
+    sessionContext.commit();
+
+    return sessionContext;
+  }
+}

--- a/src/modules/session/domain/constants/general-rules.ts
+++ b/src/modules/session/domain/constants/general-rules.ts
@@ -8,7 +8,7 @@ export const SESSION = {
     MIN_LENGTH: 1,
   },
   SESSION_DURATION: {
-    MAX_LENGTH: 50,
+    MAX_LENGTH: 999999,
     MIN_LENGTH: 1,
   },
   SESSION_CLOSED_TYPE: {

--- a/src/modules/session/domain/domain-services/activate-invalid-session.domain-service.ts
+++ b/src/modules/session/domain/domain-services/activate-invalid-session.domain-service.ts
@@ -2,11 +2,11 @@ import { SessionStatusEnum } from '@session/domain/constants/session-status.enum
 import { ISessionRepositoryContract } from '@session/domain/contracts/session-repository.contract';
 import { SessionNotValidException } from '@session/domain/exceptions/session-not-valid.exception';
 import { SessionModel } from '@session/domain/models/session.model';
-import { ISessionActivateInactivateSchemaPrimitives } from '@session/domain/schemas/session.schema-primitives';
+import { ISessionActivateInvalidSchemaPrimitives } from '@session/domain/schemas/session.schema-primitives';
 
-export class ActivateInactiveSessionDomainService {
+export class ActivateInvalidSessionDomainService {
   constructor(private readonly repositorySession: ISessionRepositoryContract) {}
-  async go(schema: ISessionActivateInactivateSchemaPrimitives): Promise<SessionModel> {
+  async go(schema: ISessionActivateInvalidSchemaPrimitives): Promise<SessionModel> {
     const sessionModel = await this.repositorySession.getOneBy(schema.uuid);
 
     if (!sessionModel) {

--- a/src/modules/session/domain/models/session.model.ts
+++ b/src/modules/session/domain/models/session.model.ts
@@ -114,8 +114,8 @@ export class SessionModel extends AggregateRoot {
     return this._entityRoot.userAgent._value;
   }
 
-  get failedAttempts(): number {
-    return this._entityRoot.failedAttempts._value;
+  get failedAttempts(): number | undefined {
+    return this._entityRoot.failedAttempts?._value;
   }
 
   get origin(): string {
@@ -221,6 +221,9 @@ export class SessionModel extends AggregateRoot {
       this._entityRoot.sessionClosedType = new SessionClosedType(entity.sessionClosedType);
     if (entity.expiresInAt) this._entityRoot.expiresInAt = new ExpiresInAt(entity.expiresInAt);
 
+    if (entity.failedAttempts)
+      this._entityRoot.failedAttempts = new SessionFailedAttempts(entity.failedAttempts);
+
     this._entityRoot.uuid = new UUID(entity.uuid);
     this._entityRoot.sessionId = new SessionId(entity.sessionId);
     this._entityRoot.sessionType = new SessionType(entity.sessionType);
@@ -229,7 +232,6 @@ export class SessionModel extends AggregateRoot {
     this._entityRoot.ipAddress = new SessionIpAddress(entity.ipAddress);
     this._entityRoot.refreshToken = new SessionRefreshToken(entity.refreshToken);
     this._entityRoot.userAgent = new SessionUserAgent(entity.userAgent);
-    this._entityRoot.failedAttempts = new SessionFailedAttempts(entity.failedAttempts);
     this._entityRoot.origin = new SessionOrigin(entity.origin);
     this._entityRoot.location = new SessionLocation(entity.location);
     this._entityRoot.createdAt = new CreatedAt(entity.createdAt);

--- a/src/modules/session/domain/schemas/session.schema-primitives.ts
+++ b/src/modules/session/domain/schemas/session.schema-primitives.ts
@@ -32,7 +32,7 @@ export interface IListSessionSchemaPrimitives {
   items: ISessionSchemaPrimitives[];
 }
 
-export type ISessionActivateInactivateSchemaPrimitives = Pick<
+export type ISessionActivateInvalidSchemaPrimitives = Pick<
   ISessionSchemaPrimitives,
   'uuid' | 'sessionDuration' | 'token' | 'expiresInAt' | 'loggedInAt' | 'refreshToken'
 >;

--- a/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.controller.ts
+++ b/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.controller.ts
@@ -13,7 +13,7 @@ export class ActivateInvalidSessionController {
   constructor(private readonly commandBus: CommandBus) {}
 
   @MessagePattern({ cmd: CMDS_HADES.SESSION.UPDATE })
-  async update(
+  async activateInvalidSession(
     @Payload() activateInactivateSessionInputDto: ActivateInvalidSessionInputDto,
   ): Promise<ActivateInvalidSessionOutputDto> {
     try {
@@ -22,11 +22,12 @@ export class ActivateInvalidSessionController {
           uuid: activateInactivateSessionInputDto.uuid,
           sessionDuration: activateInactivateSessionInputDto.sessionDuration,
           token: activateInactivateSessionInputDto.token,
-          expiresInAt: activateInactivateSessionInputDto.expiresInAt,
-          loggedInAt: activateInactivateSessionInputDto.loggedInAt,
+          expiresInAt: new Date(activateInactivateSessionInputDto.expiresInAt),
+          loggedInAt: new Date(activateInactivateSessionInputDto.loggedInAt),
           refreshToken: activateInactivateSessionInputDto.refreshToken,
         }),
       );
+
       return new ActivateInvalidSessionOutputDto(result);
     } catch (error: unknown) {
       throw new RpcException(error as Error);

--- a/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.controller.ts
+++ b/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.controller.ts
@@ -1,9 +1,10 @@
 import { Controller } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
-import { MessagePattern, Payload } from '@nestjs/microservices';
+import { MessagePattern, Payload, RpcException } from '@nestjs/microservices';
 
 import { CMDS_HADES } from '@common/infrastructure/controllers/constants';
-import { ActivateInactiveSessionCommand } from '@session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.command';
+import { ActivateInvalidSessionCommand } from '@session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.command';
+import { SessionModel } from '@session/domain/models/session.model';
 import { ActivateInvalidSessionInputDto } from '@session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.input.dto';
 import { ActivateInvalidSessionOutputDto } from '@session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.output.dto';
 
@@ -15,15 +16,20 @@ export class ActivateInvalidSessionController {
   async update(
     @Payload() activateInactivateSessionInputDto: ActivateInvalidSessionInputDto,
   ): Promise<ActivateInvalidSessionOutputDto> {
-    //TODO: Catch error with try catch and use RpcException to handle error
-    return this.commandBus.execute(
-      new ActivateInactiveSessionCommand({
-        uuid: activateInactivateSessionInputDto.uuid,
-        sessionClosedType: activateInactivateSessionInputDto.sessionClosedType,
-        loggedOutAt: activateInactivateSessionInputDto.loggedOutAt,
-        refreshToken: activateInactivateSessionInputDto.refreshToken,
-        failedAttempts: activateInactivateSessionInputDto.failedAttempts,
-      }),
-    );
+    try {
+      const result = await this.commandBus.execute<ActivateInvalidSessionCommand, SessionModel>(
+        new ActivateInvalidSessionCommand({
+          uuid: activateInactivateSessionInputDto.uuid,
+          sessionDuration: activateInactivateSessionInputDto.sessionDuration,
+          token: activateInactivateSessionInputDto.token,
+          expiresInAt: activateInactivateSessionInputDto.expiresInAt,
+          loggedInAt: activateInactivateSessionInputDto.loggedInAt,
+          refreshToken: activateInactivateSessionInputDto.refreshToken,
+        }),
+      );
+      return new ActivateInvalidSessionOutputDto(result);
+    } catch (error: unknown) {
+      throw new RpcException(error as Error);
+    }
   }
 }

--- a/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.input.dto.ts
+++ b/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.input.dto.ts
@@ -1,11 +1,12 @@
 import {
-  IsDate,
   IsNotEmpty,
-  IsOptional,
   IsString,
   IsUUID,
   Length,
   IsNumber,
+  Max,
+  Min,
+  IsISO8601,
 } from 'class-validator';
 
 import { SESSION } from '@session/domain/constants/general-rules';
@@ -16,7 +17,8 @@ export class ActivateInvalidSessionInputDto {
   public readonly uuid: string;
 
   @IsNumber()
-  @Length(SESSION.SESSION_DURATION.MIN_LENGTH, SESSION.SESSION_DURATION.MAX_LENGTH)
+  @Min(SESSION.SESSION_DURATION.MIN_LENGTH)
+  @Max(SESSION.SESSION_DURATION.MAX_LENGTH)
   @IsNotEmpty()
   public readonly sessionDuration: number;
 
@@ -25,15 +27,20 @@ export class ActivateInvalidSessionInputDto {
   @IsNotEmpty()
   public readonly token: string;
 
-  @IsDate()
+  @IsISO8601()
+  // @Transform(({ value }) => {
+  //   return new Date(value);
+  // })
   @IsNotEmpty()
-  public readonly expiresInAt: Date;
+  public readonly expiresInAt: string;
 
-  @IsOptional()
-  @IsDate()
-  public readonly loggedInAt: Date;
+  @IsISO8601()
+  // @Transform(({ value }) => {
+  //   return new Date(value);
+  // })
+  @IsNotEmpty()
+  public readonly loggedInAt: string;
 
-  @IsOptional()
   @IsString()
   @Length(SESSION.REFRESH_TOKEN.MIN_LENGTH, SESSION.REFRESH_TOKEN.MAX_LENGTH)
   public readonly refreshToken: string;

--- a/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.input.dto.ts
+++ b/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.input.dto.ts
@@ -1,11 +1,11 @@
 import {
   IsDate,
   IsNotEmpty,
-  IsNumber,
   IsOptional,
   IsString,
   IsUUID,
   Length,
+  IsNumber,
 } from 'class-validator';
 
 import { SESSION } from '@session/domain/constants/general-rules';
@@ -15,22 +15,26 @@ export class ActivateInvalidSessionInputDto {
   @IsNotEmpty()
   public readonly uuid: string;
 
+  @IsNumber()
+  @Length(SESSION.SESSION_DURATION.MIN_LENGTH, SESSION.SESSION_DURATION.MAX_LENGTH)
+  @IsNotEmpty()
+  public readonly sessionDuration: number;
+
   @IsString()
-  @IsOptional()
-  @Length(SESSION.SESSION_CLOSED_TYPE.MIN_LENGTH, SESSION.SESSION_CLOSED_TYPE.MAX_LENGTH)
-  public readonly sessionClosedType: string;
+  @Length(SESSION.TOKEN.MIN_LENGTH, SESSION.TOKEN.MAX_LENGTH)
+  @IsNotEmpty()
+  public readonly token: string;
+
+  @IsDate()
+  @IsNotEmpty()
+  public readonly expiresInAt: Date;
 
   @IsOptional()
   @IsDate()
-  public readonly loggedOutAt: Date;
+  public readonly loggedInAt: Date;
 
   @IsOptional()
   @IsString()
   @Length(SESSION.REFRESH_TOKEN.MIN_LENGTH, SESSION.REFRESH_TOKEN.MAX_LENGTH)
   public readonly refreshToken: string;
-
-  @IsNotEmpty()
-  @IsNumber()
-  @Length(SESSION.REFRESH_TOKEN.MIN_LENGTH, SESSION.REFRESH_TOKEN.MAX_LENGTH)
-  public readonly failedAttempts: number;
 }

--- a/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.output.dto.ts
+++ b/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.output.dto.ts
@@ -1,3 +1,5 @@
+import { SessionModel } from '@session/domain/models/session.model';
+
 export class ActivateInvalidSessionOutputDto {
   public readonly id: number;
   public readonly uuid: string;
@@ -6,7 +8,7 @@ export class ActivateInvalidSessionOutputDto {
   public readonly refreshToken: string;
   public readonly failedAttempts: number;
 
-  constructor(root: ActivateInvalidSessionOutputDto) {
+  constructor(root: SessionModel) {
     this.id = root.id;
     this.uuid = root.uuid;
     this.sessionClosedType = root.sessionClosedType;

--- a/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.output.dto.ts
+++ b/src/modules/session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.output.dto.ts
@@ -1,5 +1,6 @@
 import { SessionModel } from '@session/domain/models/session.model';
 
+// TODO: handler other properties to response api
 export class ActivateInvalidSessionOutputDto {
   public readonly id: number;
   public readonly uuid: string;

--- a/src/modules/session/infrastructure/framework/session.module.ts
+++ b/src/modules/session/infrastructure/framework/session.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ActiveInvalidSessionUseCase } from '@session/application/commands/use-cases/activate-invalid-session/activate-invalid-session.use-case';
 import { CreateSessionUseCase } from '@session/application/commands/use-cases/create-session/create-session.use-case';
 import { SESSION_REPOSITORY } from '@session/domain/constants/injection-tokens';
+import { ActivateInvalidSessionDomainService } from '@session/domain/domain-services/activate-invalid-session.domain-service';
 import { CreateSessionDomainService } from '@session/domain/domain-services/create-session.domain-service';
+import { ActivateInvalidSessionController } from '@session/infrastructure/controllers/commands/activate-invalid-session/activate-invalid-session.controller';
 import { CreateSessionController } from '@session/infrastructure/controllers/commands/create-session/create-session.controller';
 import { SessionEntity } from '@session/infrastructure/persistence/typeorm/entities/session.entity';
 import { SessionTypeormRepository } from '@session/infrastructure/persistence/typeorm/repositories/session-typeorm.repository';
@@ -17,6 +20,7 @@ import { AccountTypeormRepository } from '@user/infrastructure/persistence/typeo
   providers: [
     // UseCases
     CreateSessionUseCase,
+    ActiveInvalidSessionUseCase,
     // UpdateSessionUseCase,
     // ArchiveSessionUseCase,
     // DestroySessionUseCase,
@@ -25,6 +29,7 @@ import { AccountTypeormRepository } from '@user/infrastructure/persistence/typeo
 
     // Domain Services
     CreateSessionDomainService,
+    ActivateInvalidSessionDomainService,
     // UpdateSessionDomainService,
     // ArchiveSessionDomainService,
     // DestroySessionDomainService,
@@ -38,10 +43,18 @@ import { AccountTypeormRepository } from '@user/infrastructure/persistence/typeo
       inject: [ACCOUNT_REPOSITORY],
     },
     {
+      provide: ActivateInvalidSessionDomainService,
+      useFactory: (
+        sessionRepository: SessionTypeormRepository,
+      ): ActivateInvalidSessionDomainService =>
+        new ActivateInvalidSessionDomainService(sessionRepository),
+      inject: [SESSION_REPOSITORY],
+    },
+    {
       provide: SESSION_REPOSITORY,
       useClass: SessionTypeormRepository,
     },
   ],
-  controllers: [CreateSessionController],
+  controllers: [CreateSessionController, ActivateInvalidSessionController],
 })
 export class SessionModule {}

--- a/src/modules/session/infrastructure/persistence/typeorm/repositories/session-typeorm.repository.ts
+++ b/src/modules/session/infrastructure/persistence/typeorm/repositories/session-typeorm.repository.ts
@@ -49,11 +49,11 @@ export class SessionTypeormRepository
 
   public async persist(model: SessionModel): Promise<SessionModel> {
     const primitives = model.toPartialPrimitives();
-    const account = model.account.toPrimitives();
+    const account = model.account?.toPrimitives();
 
     const entity = await this.repository.save({
       ...primitives,
-      account,
+      ...(account ? { account } : {}),
     });
 
     const roleModel = new SessionModel(entity);


### PR DESCRIPTION
This pull request includes significant changes to the session activation logic, including renaming classes and methods, updating DTOs, and modifying the session model. The most important changes are listed below:

### Session Activation Logic Updates:
* Renamed `ActivateInactiveSessionCommand` to `ActivateInvalidSessionCommand` and updated its properties (`sessionClosedType` and `loggedOutAt` replaced with `sessionDuration`, `token`, `expiresInAt`, and `loggedInAt`).
* Created `ActiveInvalidSessionUseCase` to handle the `ActivateInvalidSessionCommand` and added necessary dependencies and methods for execution.
* Updated `ActivateInvalidSessionInputDto` to include new properties (`sessionDuration`, `token`, `expiresInAt`, and `loggedInAt`) and removed obsolete ones (`sessionClosedType` and `loggedOutAt`).

### Session Model and Schema Changes:
* Modified `SessionModel` to handle optional `failedAttempts` and updated its initialization logic to conditionally assign `failedAttempts`. [[1]](diffhunk://#diff-c4993357183079c8207899e2cf5d6b97c83e50a08eb3ad5aaa250795d86b765bL117-R118) [[2]](diffhunk://#diff-c4993357183079c8207899e2cf5d6b97c83e50a08eb3ad5aaa250795d86b765bR224-R226) [[3]](diffhunk://#diff-c4993357183079c8207899e2cf5d6b97c83e50a08eb3ad5aaa250795d86b765bL232)
* Renamed `ISessionActivateInactivateSchemaPrimitives` to `ISessionActivateInvalidSchemaPrimitives` to reflect the new command naming.

### Controller and Module Adjustments:
* Updated `ActivateInvalidSessionController` to handle the new command and added error handling using `RpcException`.
* Modified `SessionModule` to include new use case and domain service for activating invalid sessions. [[1]](diffhunk://#diff-24a43fc505836445a8b1a612eb54e0fff2169204e952c4344398fb5e59922af8R5-R10) [[2]](diffhunk://#diff-24a43fc505836445a8b1a612eb54e0fff2169204e952c4344398fb5e59922af8R23) [[3]](diffhunk://#diff-24a43fc505836445a8b1a612eb54e0fff2169204e952c4344398fb5e59922af8R32) [[4]](diffhunk://#diff-24a43fc505836445a8b1a612eb54e0fff2169204e952c4344398fb5e59922af8R45-R58)

### Miscellaneous:
* Increased `SESSION_DURATION.MAX_LENGTH` in `general-rules.ts` to a higher value.
* Adjusted `SessionTypeormRepository` to handle optional account information during persistence.